### PR TITLE
Add HttpContextServerVariableExtensions to Retrieve Server Variables

### DIFF
--- a/src/WebForms/HttpContextServerVariableExtensions.cs
+++ b/src/WebForms/HttpContextServerVariableExtensions.cs
@@ -1,0 +1,65 @@
+// MIT License.
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.Extensions.Primitives;
+using AspNetCoreHttpContext = Microsoft.AspNetCore.Http.HttpContext;
+
+namespace System.Web;
+
+public static class HttpContextServerVariableExtensions
+{
+    /// <summary>
+    /// Extracts a server variable with <paramref name="key"/>.
+    /// </summary>
+    /// <param name="context">The context to extract the server variable from.</param>
+    /// <param name="key">The key of the server variable.</param>
+    /// <param name="defaultValue">When no server variable was found (or empty), this value is returned instead.</param>
+    /// <returns>Found server variable (non-empty), otherwise <paramref name="defaultValue"/>.</returns>
+    public static string ServerVariable(this HttpContext systemWebContext, string key, string defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(systemWebContext);
+
+        AspNetCoreHttpContext context = systemWebContext.AsAspNetCore();
+
+        string value = string.Empty;
+
+        switch (key.ToUpperInvariant())
+        {
+            case "HTTP_REFERER":
+                value = context.Request.Headers.Referer.ToString();
+                break;
+            case "REMOTE_ADDR":
+                value = context.Connection.RemoteIpAddress?.ToString();
+                break;
+            case "SERVER_NAME":
+                value = context.Request.Host.Host;
+                break;
+            case "SERVER_PORT":
+                value = context.Request.Host.Port.ToString();
+                break;
+            case "REQUEST_METHOD":
+                value = context.Request.Method;
+                break;
+            case "QUERY_STRING":
+                value = context.Request.QueryString.Value;
+                break;
+            case "REMOTE_PORT":
+                value = context.Connection.RemotePort.ToString();
+                break;
+            case "HTTP_USER_AGENT":
+                value = context.Request.Headers.UserAgent.ToString();
+                break;
+            case "PATH_INFO":
+                value = context.Request.Path.ToString();
+                break;
+            default:
+                if (context.Request.Headers.TryGetValue(key, out StringValues headerValue))
+                {
+                    value = headerValue.ToString();
+                }
+
+                break;
+        }
+
+        return !string.IsNullOrWhiteSpace(value) ? value : defaultValue;
+    }
+}

--- a/src/WebForms/UI/ViewStateException.cs
+++ b/src/WebForms/UI/ViewStateException.cs
@@ -59,11 +59,11 @@ public sealed class ViewStateException : Exception, ISerializable
         HttpResponse response = context != null ? context.Response : null;
 
         _isConnected = response.IsClientConnected;
-        _remoteAddr = request.ServerVariables["REMOTE_ADDR"];
-        _remotePort = request.ServerVariables["REMOTE_PORT"];
-        _userAgent = request.ServerVariables["HTTP_USER_AGENT"];
-        _referer = request.ServerVariables["HTTP_REFERER"];
-        _path = request.ServerVariables["PATH_INFO"];
+        _remoteAddr = context.ServerVariable("REMOTE_ADDR", string.Empty);
+        _remotePort = context.ServerVariable("REMOTE_PORT", string.Empty);
+        _userAgent = context.ServerVariable("HTTP_USER_AGENT", string.Empty);
+        _referer = context.ServerVariable("HTTP_REFERER", string.Empty);
+        _path = context.ServerVariable("PATH_INFO", string.Empty);
 
         string debugInfo = String.Format(CultureInfo.InvariantCulture,
                                          _format,

--- a/test/Webforms.Tests/HttpContextVariableTests.cs
+++ b/test/Webforms.Tests/HttpContextVariableTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HttpContextServerVariableExtensions = System.Web.HttpContextServerVariableExtensions;
+
+namespace WebForms.Tests;
+
+[TestClass]
+public class HttpContextVariableTests
+{
+    [TestMethod]
+    [DataRow("HTTP_REFERER", "http://example.com", "Referer")]
+    [DataRow("REMOTE_ADDR", "127.0.0.1", "RemoteIpAddress")]
+    [DataRow("SERVER_NAME", "example.com", "Host")]
+    [DataRow("SERVER_PORT", "80", "ServerPort")]
+    [DataRow("REQUEST_METHOD", "POST", "Method")]
+    [DataRow("QUERY_STRING", "?key=value", "QueryString")]
+    [DataRow("REMOTE_PORT", "12345", "RemotePort")]
+    [DataRow("HTTP_USER_AGENT", "Mozilla/5.0", "User-Agent")]
+    [DataRow("PATH_INFO", "/path/info", "Path")]
+    public void ServerVariable_ReturnsExpectedValue(string systemWebVariable, string value,
+        string aspNetCoreVariable)
+    {
+        DefaultHttpContext context = new DefaultHttpContext();
+
+        switch (aspNetCoreVariable)
+        {
+            case "Referer":
+                context.Request.Headers.Referer = value;
+                break;
+            case "RemoteIpAddress":
+                context.Connection.RemoteIpAddress = IPAddress.Parse(value);
+                break;
+            case "Host":
+                context.Request.Host = new HostString(value);
+                break;
+            case "Method":
+                context.Request.Method = value;
+                break;
+            case "QueryString":
+                context.Request.QueryString = new QueryString(value);
+                break;
+            case "RemotePort":
+                bool isValidPort = int.TryParse(value, out int remotePort);
+                if (!isValidPort)
+                {
+                    throw new FormatException("Invalid port number");
+                }
+
+                context.Connection.RemotePort = remotePort;
+                break;
+            case "User-Agent":
+                context.Request.Headers["User-Agent"] = value;
+                break;
+            case "Path":
+                context.Request.Path = value;
+                break;
+            case "ServerPort":
+                bool isValidServerPort = int.TryParse(value, out int serverPort);
+                if (!isValidServerPort)
+                {
+                    throw new FormatException("Invalid port number");
+                }
+
+                context.Request.Host = new HostString(context.Request.Host.Host, serverPort);
+                break;
+            default:
+                throw new Exception("Unknown variable");
+        }
+
+        string? result = HttpContextServerVariableExtensions.ServerVariable(context, systemWebVariable, string.Empty);
+
+        Assert.AreEqual(value, result);
+    }
+
+    [TestMethod]
+    [DataRow("NON_EXISTENT_KEY", "sample", "NonExistentKey", "default")]
+    public void ServerVariable_ReturnsDefaultValueForNonExistentKey(string systemWebVariable, string value,
+        string aspNetCoreVariable, string expectedValue)
+    {
+        DefaultHttpContext context = new();
+
+        context.Request.Headers[aspNetCoreVariable] = value;
+        string result = HttpContextServerVariableExtensions.ServerVariable(context, systemWebVariable, expectedValue);
+
+        Assert.AreEqual(expectedValue, result);
+    }
+}


### PR DESCRIPTION
…in .NET Core

Previously, accessing server variables such as REMOTE_ADDR relied on an approach that wasn't supported in .NET Core, causing limitations in functionality. To resolve this, a new method has been introduced that simplifies the process of retrieving these values from the current context. This change ensures compatibility with .NET Core while maintaining access to key server information in a more flexible and efficient way.